### PR TITLE
Also call a preventDefault to prevent leaving

### DIFF
--- a/dist/jquery.dirty.js
+++ b/dist/jquery.dirty.js
@@ -31,8 +31,9 @@
         });
 
         if (d.options.preventLeaving) {
-            $(window).on("beforeunload", function() {
+            $(window).on("beforeunload", function(event) {
                 if (d.isDirty && !d.submitting) {
+                    event.preventDefault();
                     return d.options.leavingMessage;
                 }
             });


### PR DESCRIPTION
As seen [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event), the standard way to ask for a confirmation is to default prevent the event, with no mean to specify the message : 
> According to the specification, to show the confirmation dialog an event handler should call preventDefault() on the event.

Still keeping the old `return` because  : 
> However note that not all browsers support this method, and some instead require the event handler to implement one of two legacy methods:
> * assigning a string to the event's returnValue property
> * returning a string from the event handler.